### PR TITLE
feature:댓글 수정

### DIFF
--- a/study/spring-board/src/main/java/com/kms/springboard/comment/service/CommentService.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/comment/service/CommentService.java
@@ -3,12 +3,16 @@ package com.kms.springboard.comment.service;
 
 import com.kms.springboard.comment.dto.CommentDto;
 
+import com.kms.springboard.comment.entity.CommentEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import javax.xml.stream.events.Comment;
 
 public interface CommentService {
     CommentDto createComment(CommentDto request);
     Page<CommentDto> findByBoardId(Long boardId, Pageable pageable);
     Page<CommentDto> findByUserId(String userId, Pageable pageable);
+    CommentDto updateComment(Long commentId, CommentDto request);
 
 }

--- a/study/spring-board/src/main/java/com/kms/springboard/post/service/BoardServiceImpl.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/post/service/BoardServiceImpl.java
@@ -104,7 +104,7 @@ public class BoardServiceImpl implements BoardService {
         BoardEntity boardEntity = boardRepository.findById(boardId)
                 .orElseThrow(() -> new EntityNotFoundException("Board not found:" + boardId));
         var auth = SecurityContextHolder.getContext().getAuthentication();
-        final String currentUser = auth == null?null:auth.getName();
+        final String currentUser = auth == null ? null:auth.getName();
         if(!Objects.equals(boardEntity.getWriter(),currentUser)) {
             throw new AccessDeniedException("해당 게시물 작성자가 아닙니다");
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 댓글 수정 API 추가(PUT /api/comments/{commentId}): 인증된 작성자만 수정 가능, 성공 시 변경된 댓글 반환
  - 오류/권한 응답 정교화: 미인증 401, 작성자 불일치 403(“작성자만 수정할 수 있습니다.”), 미존재 404(“해당 댓글은 존재하지 않습니다”)
- 스타일
  - 코드 가독성을 위한 공백 정리(동작 변경 없음)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->