### PR TITLE
feature:댓글 삭제

### DIFF
--- a/study/spring-board/src/main/java/com/kms/springboard/comment/controller/CommentController.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/comment/controller/CommentController.java
@@ -31,14 +31,15 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/api/comments")
+@RequestMapping("/api/boards/{boardId}")
 public class CommentController {
     private final CommentService commentService;
     private final MemberRepository memberRepository;
 
 
-    @PostMapping
+    @PostMapping("/comments")
     public ResponseEntity<ApiResponse<CommentDto>> createComment(
+            @PathVariable Long boardId,
             @Valid @RequestBody CommentDto request,
             Authentication auth) {
         try{
@@ -46,7 +47,7 @@ public class CommentController {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                         .body(ApiResponse.error("인증이 필요합니다"));
             }
-            CommentDto savedComment = commentService.createComment(request);
+            CommentDto savedComment = commentService.createComment(boardId,request);
             return ResponseEntity.status(HttpStatus.CREATED)
                     .body(ApiResponse.success("댓글 작성 완료",savedComment));
         } catch (EntityNotFoundException e) {
@@ -56,7 +57,7 @@ public class CommentController {
 
     }
 
-    @GetMapping("/boards/{boardId}")
+    @GetMapping("/comments")
     public ResponseEntity<ApiResponse<Page<CommentDto>>> getCommentsByBoardId(
             @PathVariable Long boardId,
             @RequestParam(defaultValue = "0") @PositiveOrZero int page,
@@ -121,5 +122,16 @@ public class CommentController {
         }
 
     }
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(@PathVariable Long commentId, Authentication auth) {
+        try {
+            commentService.deleteComment(commentId, auth);
+            return ResponseEntity.ok(ApiResponse.success("댓글 삭제 완료", null));
+        } catch (AccessDeniedException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.error("해당 댓글이 존재하지 않습니다"));
+        }
+    }
+
 
 }

--- a/study/spring-board/src/main/java/com/kms/springboard/comment/dto/CommentDto.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/comment/dto/CommentDto.java
@@ -21,8 +21,7 @@ public class CommentDto {
     private String content;
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private String writer;
-    @NotNull(message = "게시글 ID가 필요합니다")
-    private Long boardId;
+
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private String userId;
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)

--- a/study/spring-board/src/main/java/com/kms/springboard/comment/service/CommentService.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/comment/service/CommentService.java
@@ -6,13 +6,15 @@ import com.kms.springboard.comment.dto.CommentDto;
 import com.kms.springboard.comment.entity.CommentEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 
 import javax.xml.stream.events.Comment;
 
 public interface CommentService {
-    CommentDto createComment(CommentDto request);
+    CommentDto createComment(Long boardId,CommentDto request);
     Page<CommentDto> findByBoardId(Long boardId, Pageable pageable);
     Page<CommentDto> findByUserId(String userId, Pageable pageable);
     CommentDto updateComment(Long commentId, CommentDto request);
+    void deleteComment(Long commentId, Authentication auth);
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 댓글 삭제 API 추가(인증 필요). 삭제 시 존재하지 않거나 권한이 없으면 404 유사 응답을 반환합니다.
* 리팩터링
  * 댓글 API 경로를 게시글 컨텍스트 하위로 재구성: 기본 경로를 /api/comments에서 /api/boards/{boardId}로 변경.
  * 댓글 생성/조회 경로를 /comments로 통합하고, 경로의 boardId를 사용하도록 변경.
  * 요청/응답에서 댓글 DTO의 boardId 필드를 제거하여 클라이언트가 별도 전달하지 않아도 되도록 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->