### PR TITLE
refactor:jwt, member, security / add: redis

### DIFF
--- a/study/spring-board/docker-compose.yml
+++ b/study/spring-board/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   redis:
     image: redis:alpine

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/controller/AuthController.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/controller/AuthController.java
@@ -1,10 +1,19 @@
 package com.kms.springboard.auth.controller;
 
 
+import com.kms.springboard.auth.dto.JwtTokenResponse;
+import com.kms.springboard.auth.dto.LoginDto;
+import com.kms.springboard.auth.dto.RefreshTokenRequestDto;
+import com.kms.springboard.auth.service.AuthService;
+import com.kms.springboard.common.dto.ApiResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -12,5 +21,53 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private final Au
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<JwtTokenResponse>>login(
+            @Valid @RequestBody LoginDto loginDto,
+            HttpServletResponse response){
+        log.info("Login attempt for user: {}", loginDto.getUserId());
+
+        JwtTokenResponse tokenResponse = authService.login(loginDto);
+        authService.setRefreshTokenCookie(response, tokenResponse.getRefreshToken());
+
+        return ResponseEntity.ok(ApiResponse.success("로그인 성공", tokenResponse));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<JwtTokenResponse>> logout(
+            HttpServletRequest request,
+            @CookieValue(value = "REFRESH_TOKEN", required = false)String refreshToken,
+            HttpServletResponse response){
+
+        String authHeader = request.getHeader("Authorization");
+        log.info("Logout attempt for user: {}", authHeader);
+        log.info("Refresh token: {}", refreshToken);
+        authService.logout(authHeader,refreshToken,response);
+
+        return ResponseEntity.ok(ApiResponse.success("로그아웃되었습니다",null));
+
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<JwtTokenResponse>> refresh(
+            @CookieValue(value = "REFRESH_TOKEN", required = false)String cookieRefreshToken,
+            @RequestBody(required = false)RefreshTokenRequestDto requestBody,
+            HttpServletResponse response){
+
+        String refreshToken = requestBody != null && requestBody.getRefreshToken() != null
+                ? requestBody.getRefreshToken()
+                :cookieRefreshToken;
+
+        log.info("Refresh attempt for user: {}", refreshToken);
+
+        JwtTokenResponse tokenResponse = authService.refreshToken(refreshToken);
+        authService.setRefreshTokenCookie(response, tokenResponse.getRefreshToken());
+
+        return ResponseEntity.ok(ApiResponse.success("토큰 쿠키 설정 완료",tokenResponse));
+    }
+
+
+
 }

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/controller/AuthController.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/controller/AuthController.java
@@ -1,0 +1,16 @@
+package com.kms.springboard.auth.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final Au
+}

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/dto/JwtTokenResponse.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/dto/JwtTokenResponse.java
@@ -1,4 +1,4 @@
-package com.kms.springboard.security.jwt.dto;
+package com.kms.springboard.auth.dto;
 
 
 import lombok.AllArgsConstructor;

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/dto/LoginDto.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/dto/LoginDto.java
@@ -1,7 +1,6 @@
-package com.kms.springboard.member.dto;
+package com.kms.springboard.auth.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/dto/RefreshTokenRequestDto.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/dto/RefreshTokenRequestDto.java
@@ -1,0 +1,13 @@
+package com.kms.springboard.auth.dto;
+
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class RefreshTokenRequestDto {
+    private String refreshToken;
+}

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtAuthenticationFilter.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,4 @@
-package com.kms.springboard.security.jwt;
+package com.kms.springboard.auth.jwt;
 
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenGenerator.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenGenerator.java
@@ -1,17 +1,10 @@
-package com.kms.springboard.security.jwt;
+package com.kms.springboard.auth.jwt;
 
-import com.kms.springboard.security.jwt.dto.JwtTokenResponse;
-import io.jsonwebtoken.Jwt;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.io.Decoders;
-import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
+import com.kms.springboard.auth.dto.JwtTokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.security.Key;
 import java.util.Date;
 
 @Component
@@ -27,7 +20,7 @@ public class JwtTokenGenerator {
     private long refreshTokenExpiration;
 
 
-   public JwtTokenResponse generateToken(String userId){
+   public JwtTokenResponse generateToken(String userId) {
        Date now = new Date();
        Date accessTokenExpiryDate = new Date(now.getTime() + accessTokenExpiration);
        Date refreshTokenExpiryDate = new Date(now.getTime() + refreshTokenExpiration);
@@ -38,18 +31,9 @@ public class JwtTokenGenerator {
        return JwtTokenResponse.of(
                accessToken,
                refreshToken,
-               accessTokenExpiration / 1000,
+               accessTokenExpiration,
                "Bearer"
        );
    }
-
-    public String generateAccessToken(String userId) {
-       Date now = new Date();
-       Date accessTokenExpiryDate = new Date(now.getTime() + accessTokenExpiration);
-
-       return jwtTokenProvider.generate(userId, accessTokenExpiryDate);
-    }
-
-
 
 }

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenGenerator.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenGenerator.java
@@ -31,7 +31,7 @@ public class JwtTokenGenerator {
        return JwtTokenResponse.of(
                accessToken,
                refreshToken,
-               accessTokenExpiration,
+               accessTokenExpiration/1000L,
                "Bearer"
        );
    }

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenProvider.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenProvider.java
@@ -27,8 +27,6 @@ public class JwtTokenProvider {
 
     @PostConstruct
     public void init() {
-        log.info("jwt secret: {}", jwtSecret);
-
         byte[] secretBytes;
         try{
             secretBytes = Decoders.BASE64.decode(jwtSecret);
@@ -61,7 +59,7 @@ public class JwtTokenProvider {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
         }catch (JwtException | IllegalArgumentException e) {
-            log.debug("Invalid JWT token", e);
+            log.debug("Invalid JWT token: {}", e.getMessage());
             return false;
         }
     }

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenProvider.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenProvider.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
+
 @Slf4j
 @Component
 public class JwtTokenProvider {
@@ -26,6 +27,8 @@ public class JwtTokenProvider {
 
     @PostConstruct
     public void init() {
+        log.info("jwt secret: {}", jwtSecret);
+
         byte[] secretBytes;
         try{
             secretBytes = Decoders.BASE64.decode(jwtSecret);

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenProvider.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenProvider.java
@@ -1,4 +1,4 @@
-package com.kms.springboard.security.jwt;
+package com.kms.springboard.auth.jwt;
 
 
 import io.jsonwebtoken.Claims;
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 @Slf4j
@@ -21,14 +22,19 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private String jwtSecret;
 
-
-
     private Key key;
 
     @PostConstruct
     public void init() {
-        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(jwtSecret));
+        byte[] secretBytes;
+        try{
+            secretBytes = Decoders.BASE64.decode(jwtSecret);
+        }catch (IllegalArgumentException e){
+            secretBytes = jwtSecret.getBytes(StandardCharsets.UTF_8);
+        }
+        key = Keys.hmacShaKeyFor(secretBytes);
     }
+
     public String generate(String subject, Date expiredAt){
         return Jwts.builder()
                 .setSubject(subject)
@@ -37,10 +43,6 @@ public class JwtTokenProvider {
                 .signWith(key, SignatureAlgorithm.HS512)
                 .compact();
     }
-
-
-
-
 
     public String getUserIdFromToken(String token) {
         Claims claims = Jwts.parserBuilder()

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenValidator.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/jwt/JwtTokenValidator.java
@@ -1,4 +1,4 @@
-package com.kms.springboard.security.jwt;
+package com.kms.springboard.auth.jwt;
 
 
 import lombok.RequiredArgsConstructor;

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/service/AuthService.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/service/AuthService.java
@@ -1,0 +1,17 @@
+package com.kms.springboard.auth.service;
+
+import com.kms.springboard.auth.dto.JwtTokenResponse;
+import com.kms.springboard.auth.dto.LoginDto;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface AuthService {
+
+    JwtTokenResponse login(LoginDto loginDto);
+    JwtTokenResponse refreshToken(String refreshToken);
+
+    void logout(String authHeader, String refreshToken, HttpServletResponse response);
+
+    void setRefreshTokenCookie(HttpServletResponse response, String refreshToken);
+
+    boolean validateToken(String authHeader);
+}

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/service/AuthServiceImpl.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/service/AuthServiceImpl.java
@@ -1,0 +1,153 @@
+package com.kms.springboard.auth.service;
+
+import com.kms.springboard.auth.dto.JwtTokenResponse;
+import com.kms.springboard.auth.dto.LoginDto;
+import com.kms.springboard.auth.jwt.JwtTokenGenerator;
+import com.kms.springboard.auth.jwt.JwtTokenProvider;
+import com.kms.springboard.auth.jwt.JwtTokenValidator;
+import com.kms.springboard.common.Normalizer;
+import com.kms.springboard.member.entity.MemberEntity;
+import com.kms.springboard.member.repository.MemberRepository;
+import io.netty.util.internal.StringUtil;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class AuthServiceImpl implements AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenGenerator jwtTokenGenerator;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenValidator jwtTokenValidator;
+    private final TokenService tokenService;
+    private final Normalizer normalizer;
+
+
+    @Override
+    public JwtTokenResponse login(LoginDto loginDto) {
+        String normalizedUserId = normalizer.normalize(loginDto.getUserId());
+
+        MemberEntity member = memberRepository.findByUserId(normalizedUserId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다"));
+
+        if(!passwordEncoder.matches(loginDto.getPassword(), member.getPassword())) {
+            throw new BadCredentialsException(" 비밀번호가 일치하지 않습니다");
+        }
+        JwtTokenResponse tokenResponse = jwtTokenGenerator.generateToken(normalizedUserId);
+
+        tokenService.saveRefreshToken(normalizedUserId, tokenResponse.getRefreshToken());
+
+        log.info("사용자 로그인 성공: {}", normalizedUserId);
+        return tokenResponse;
+    }
+
+    @Override
+    public JwtTokenResponse refreshToken(String refreshToken) {
+        if(!StringUtils.hasText(refreshToken)) {
+            throw new BadCredentialsException("Refresh token이 필요합니다")
+        }
+        if(!jwtTokenValidator.validate(refreshToken)) {
+            throw new BadCredentialsException("유효하지 않은 refresh token입니다");
+        }
+
+        String userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+
+        if(!tokenService.validateRefreshToken(userId, refreshToken)) {
+            throw new BadCredentialsException("저장된 refresh token과 일치하지 않습니다");
+        }
+
+        JwtTokenResponse newTokenResponse = jwtTokenGenerator.generateToken(userId);
+
+        tokenService.deleteRefreshToken(userId);
+        tokenService.saveRefreshToken(userId, newTokenResponse.getRefreshToken());
+
+        log.info("토큰 리프레시 완료: {}", userId);
+
+        return newTokenResponse;
+    }
+
+
+    @Override
+    public void logout(String authHeader, String refreshToken, HttpServletResponse response) {
+        String userId = null;
+
+        if(StringUtils.hasText(authHeader) &&  authHeader.startsWith("Bearer ")) {
+            String accessToken = authHeader.substring(7);
+
+            try{
+                userId = jwtTokenProvider.getUserIdFromToken(accessToken);
+                tokenService.addToBlacklist(accessToken);
+                log.debug("Access token 블랙리스트 추가 완료");
+            }catch(Exception e){
+                log.warn("Access token 처리 중 오류 발생: {}", e.getMessage());
+            }
+        }
+
+        if(StringUtils.hasText(refreshToken) && userId != null) {
+            tokenService.deleteRefreshToken(userId);
+            log.debug("Refresh token 삭제 완료");
+        }
+
+        clearRefreshTokenCookie(response);
+
+        if(userId != null) {
+            log.info("사용자 로그안웃 완료: {}", userId);
+        }
+    }
+
+    @Override
+    public void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie("REFRESH_TOKEN", refreshToken);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);
+        cookie.setMaxAge(7 * 24 * 60 * 60);
+
+        response.addCookie(cookie);
+        log.debug("Refresh token 쿠키 설정 완료");
+    }
+
+    @Override
+    public boolean validateToken(String authHeader) {
+        if(!StringUtils.hasText(authHeader)) {
+            return false;
+        }
+
+        String token = authHeader.substring(7);
+
+        if(!jwtTokenValidator.validate(token)) {
+            return false;
+
+        }
+        if (tokenService.isBlacklisted(token)) {
+            log.debug("블랙리스트에 등록된 토큰입니다");
+            return false;
+        }
+        return true;
+    }
+
+
+    private void clearRefreshTokenCookie(HttpServletResponse response) {
+        Cookie cookie = new Cookie("REFRESH_TOKEN", null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(false);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+
+        response.addCookie(cookie);
+        log.debug("Refresh token 쿠키 삭제 완료");
+    }
+}

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/service/AuthServiceImpl.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/service/AuthServiceImpl.java
@@ -57,7 +57,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public JwtTokenResponse refreshToken(String refreshToken) {
         if(!StringUtils.hasText(refreshToken)) {
-            throw new BadCredentialsException("Refresh token이 필요합니다")
+            throw new BadCredentialsException("Refresh token이 필요합니다");
         }
         if(!jwtTokenValidator.validate(refreshToken)) {
             throw new BadCredentialsException("유효하지 않은 refresh token입니다");
@@ -95,7 +95,7 @@ public class AuthServiceImpl implements AuthService {
                 log.warn("Access token 처리 중 오류 발생: {}", e.getMessage());
             }
         }
-
+        log.info("Logout attempt for user: {}", userId);
         if(StringUtils.hasText(refreshToken) && userId != null) {
             tokenService.deleteRefreshToken(userId);
             log.debug("Refresh token 삭제 완료");
@@ -113,7 +113,7 @@ public class AuthServiceImpl implements AuthService {
         Cookie cookie = new Cookie("REFRESH_TOKEN", refreshToken);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
-        cookie.setSecure(false);
+        cookie.setSecure(true);
         cookie.setMaxAge(7 * 24 * 60 * 60);
 
         response.addCookie(cookie);

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/service/RedisTokenService.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/service/RedisTokenService.java
@@ -18,7 +18,7 @@ public class RedisTokenService implements TokenService {
     @Value("${jwt.refresh-expiration-ms}")
     private long refreshExpirationMs;
 
-    @Value("${jwt.accsss-expiration-ms}")
+    @Value("${jwt.access-expiration-ms}")
     private long accessExpirationMs;
 
     private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/service/RedisTokenService.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/service/RedisTokenService.java
@@ -1,0 +1,66 @@
+package com.kms.springboard.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RedisTokenService implements TokenService {
+
+    private final RedisTemplate<String, String>stringRedisTemplate;
+
+    @Value("${jwt.refresh-expiration-ms}")
+    private long refreshExpirationMs;
+
+    @Value("${jwt.accsss-expiration-ms}")
+    private long accessExpirationMs;
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
+    private static final String BLACKLIST_PREFIX = "blacklist";
+
+    @Override
+    public void saveRefreshToken(String userId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        Duration expiration = Duration.ofMillis(refreshExpirationMs);
+        stringRedisTemplate.opsForValue().set(key, refreshToken, expiration);
+        log.debug("Redis: Refresh token 저장 - 사용자: {}", userId);
+    }
+
+    @Override
+    public boolean validateRefreshToken(String userId, String refreshToken) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        String storedToken = stringRedisTemplate.opsForValue().get(key);
+        boolean isValid = refreshToken.equals(storedToken);
+        log.debug("Redis: Refresh token 검증 - 사용자 {}: {}", userId, isValid);
+        return isValid;
+    }
+
+    @Override
+    public void deleteRefreshToken(String userId) {
+        String key = REFRESH_TOKEN_PREFIX + userId;
+        stringRedisTemplate.delete(key);
+        log.debug("Redis: Refresh token 삭제 - 사용자: {}", userId);
+    }
+
+    @Override
+    public void addToBlacklist(String accessToken) {
+        String key = BLACKLIST_PREFIX + accessToken;
+        Duration expriation = Duration.ofMillis(accessExpirationMs);
+        stringRedisTemplate.opsForValue().set(key, "blacklist", expriation);
+        log.debug("Redis: 블랙리스트 추가");
+    }
+
+    @Override
+    public boolean isBlacklisted(String accessToken) {
+        String key = BLACKLIST_PREFIX + accessToken;
+        Boolean exists = stringRedisTemplate.hasKey(key);
+        boolean isBlacklisted = Boolean.TRUE.equals(exists);
+        return isBlacklisted;
+    }
+}

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/service/RedisTokenService.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/service/RedisTokenService.java
@@ -22,7 +22,7 @@ public class RedisTokenService implements TokenService {
     private long accessExpirationMs;
 
     private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
-    private static final String BLACKLIST_PREFIX = "blacklist";
+    private static final String BLACKLIST_PREFIX = "blacklist:";
 
     @Override
     public void saveRefreshToken(String userId, String refreshToken) {
@@ -51,8 +51,8 @@ public class RedisTokenService implements TokenService {
     @Override
     public void addToBlacklist(String accessToken) {
         String key = BLACKLIST_PREFIX + accessToken;
-        Duration expriation = Duration.ofMillis(accessExpirationMs);
-        stringRedisTemplate.opsForValue().set(key, "blacklist", expriation);
+        Duration expiration = Duration.ofMillis(accessExpirationMs);
+        stringRedisTemplate.opsForValue().set(key, "blacklist", expiration);
         log.debug("Redis: 블랙리스트 추가");
     }
 

--- a/study/spring-board/src/main/java/com/kms/springboard/auth/service/TokenService.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/auth/service/TokenService.java
@@ -1,0 +1,10 @@
+package com.kms.springboard.auth.service;
+
+public interface TokenService {
+    void saveRefreshToken(String userId, String refreshToken);
+    boolean validateRefreshToken(String userId, String refreshToken);
+    void deleteRefreshToken(String userId);
+    void addToBlacklist(String accessToken);
+    boolean isBlacklisted(String accessToken);
+
+}

--- a/study/spring-board/src/main/java/com/kms/springboard/common/Normalizer.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/common/Normalizer.java
@@ -1,8 +1,6 @@
 package com.kms.springboard.common;
 
 
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Locale;
@@ -12,6 +10,13 @@ import java.util.Locale;
 public class Normalizer {
 
     public String normalize(String user) {
-        return user==null ? "" : user.trim().toLowerCase(Locale.ROOT);
+        if (user == null) {
+            throw new IllegalArgumentException("정규화할 문자열이 null입니다");
+        }
+        var trimmeed = user.trim();
+        if(trimmeed.isEmpty()) {
+            throw new IllegalArgumentException("정규화할 문자열이 비어 있습니다");
+        }
+        return trimmeed.toLowerCase(Locale.ROOT);
     }
 }

--- a/study/spring-board/src/main/java/com/kms/springboard/common/Normalizer.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/common/Normalizer.java
@@ -1,0 +1,17 @@
+package com.kms.springboard.common;
+
+
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+
+
+@Component
+public class Normalizer {
+
+    public String normalize(String user) {
+        return user==null ? "" : user.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/study/spring-board/src/main/java/com/kms/springboard/config/RedisConfig.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/config/RedisConfig.java
@@ -1,0 +1,47 @@
+package com.kms.springboard.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@Slf4j
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host:localhost}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port:6379}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redisHost, redisPort);
+
+        log.info("Redis 연결 설정: {}:{} ", redisHost, redisPort);
+        return new LettuceConnectionFactory(config);
+    }
+    @Bean
+    public RedisTemplate<String, String> stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String,String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        template.setKeySerializer(stringSerializer);
+        template.setValueSerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setHashValueSerializer(stringSerializer);
+
+        template.afterPropertiesSet();
+        log.info("Docker Redis Template 설정 완료");
+        return template;
+
+    }
+
+}

--- a/study/spring-board/src/main/java/com/kms/springboard/config/SecurityConfig.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/","/api/boards","/auth/**").permitAll()
+                        .requestMatchers("/","/api/boards","/api/auth/**").permitAll()
                         .requestMatchers(HttpMethod.POST,"/api/users/login","/api/users/register").permitAll()
                         .anyRequest().authenticated()
                 );
@@ -45,4 +45,5 @@ public class SecurityConfig {
     JwtAuthenticationFilter jwtAuthenticationFilter(){
         return new JwtAuthenticationFilter(jwtTokenProvider);
     }
+
 }

--- a/study/spring-board/src/main/java/com/kms/springboard/config/SecurityConfig.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.kms.springboard.security.config;
+package com.kms.springboard.config;
 
 
 import com.kms.springboard.auth.jwt.JwtAuthenticationFilter;

--- a/study/spring-board/src/main/java/com/kms/springboard/docker/docker-compose.yml
+++ b/study/spring-board/src/main/java/com/kms/springboard/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  redis:
+    image: redis:alpine
+    container_name: spring-board-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes
+    restart: unless-stopped
+
+
+volumes:
+  redis-data:

--- a/study/spring-board/src/main/java/com/kms/springboard/member/controller/MemberController.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/member/controller/MemberController.java
@@ -1,33 +1,22 @@
 package com.kms.springboard.member.controller;
 
 import com.kms.springboard.common.dto.ApiResponse;
-import com.kms.springboard.member.dto.LoginDto;
-import com.kms.springboard.member.dto.LoginResponse;
 import com.kms.springboard.member.dto.MemberDto;
 import com.kms.springboard.member.dto.MemberResponseDto;
-import com.kms.springboard.member.entity.MemberEntity;
 import com.kms.springboard.member.service.MemberService;
-import com.kms.springboard.security.jwt.JwtTokenGenerator;
-import com.kms.springboard.security.jwt.JwtTokenProvider;
-import com.kms.springboard.security.jwt.JwtTokenValidator;
-import com.kms.springboard.security.jwt.dto.JwtTokenResponse;
-import jakarta.persistence.EntityNotFoundException;
+import com.kms.springboard.auth.jwt.JwtTokenGenerator;
+import com.kms.springboard.auth.jwt.JwtTokenProvider;
+import com.kms.springboard.auth.jwt.JwtTokenValidator;
 import jakarta.validation.Valid;
-import lombok.Builder;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+
 
 @Slf4j
 @RestController
@@ -36,9 +25,6 @@ import java.util.Optional;
 @RequestMapping("/api/users")
 public class MemberController {
     private final MemberService memberService;
-    private final JwtTokenValidator jwtTokenValidator;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final JwtTokenGenerator jwtTokenGenerator;
 
     @PostMapping("/register")
     public ResponseEntity<ApiResponse<Void>> register(@Valid @RequestBody MemberDto memberDto){
@@ -51,93 +37,6 @@ public class MemberController {
             return ResponseEntity.badRequest()
                     .body(ApiResponse.error("회원가입 실패"));
 
-        }
-    }
-    @PostMapping("/login")
-    public ResponseEntity<ApiResponse<JwtTokenResponse>> login(@Valid @RequestBody LoginDto loginDto) {
-        try {
-            JwtTokenResponse tokenResponse = memberService.login(loginDto);
-
-            var accessTokenCookie = ResponseCookie.from("ACCESS_TOKEN", tokenResponse.getAccessToken())
-                    .httpOnly(true)
-                    .secure(false)
-                    .sameSite("Lax")
-                    .path("/")
-                    .maxAge(3600)
-                    .build();
-
-            var refreshTokenCookie = ResponseCookie.from("REFRESH_TOKEN", tokenResponse.getRefreshToken())
-                    .httpOnly(true)
-                    .secure(false)
-                    .sameSite("Lax")
-                    .path("/")
-                    .maxAge(3600 * 24 * 7)
-                    .build();
-            return ResponseEntity.ok()
-                    .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-                    .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
-                    .body(ApiResponse.success("로그인 성공", tokenResponse));
-        } catch (EntityNotFoundException e) {
-            log.warn("로그인 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(ApiResponse.error("로그인 실패:"));
-        }catch (Exception e){
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.error("로그인 처리 중 오류 발생했습니다"));
-        }
-
-
-    }
-    @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<JwtTokenResponse>>refresh(
-            @CookieValue(value = "REFRESH_TOKEN",required = false)String refreshToken,
-            @RequestBody(required = false)Map<String,String> requestBody){
-        try{
-            String token = refreshToken;
-            if(token == null && requestBody != null){
-                token = requestBody.get("refresh_token");
-            }
-            if(token == null){
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(ApiResponse.error("Refresh token이 필요합니다"));
-            }
-
-            if(!jwtTokenValidator.validate(token)){
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(ApiResponse.error("유효하지 않은 refresh token입니다"));
-            }
-
-            String userId = jwtTokenProvider.getUserIdFromToken(token);
-            if(userId.startsWith("refresh:")){
-                userId = userId.substring(8);
-            }
-
-            JwtTokenResponse newToken = jwtTokenGenerator.generateToken(userId);
-
-            var accessTokenCookie = ResponseCookie.from("ACCESS_TOKEN", newToken.getAccessToken())
-                    .httpOnly(true)
-                    .secure(false)
-                    .sameSite("Lax")
-                    .path("/")
-                    .maxAge(3600)
-                    .build();
-
-            var newRefreshTokenCookie = ResponseCookie.from("REFRESH_TOKEN", newToken.getRefreshToken())
-                    .httpOnly(true)
-                    .secure(false)
-                    .sameSite("Lax")
-                    .path("/")
-                    .maxAge(3600 * 24 * 7)
-                    .build();
-
-            return ResponseEntity.ok()
-                    .header(HttpHeaders.SET_COOKIE,accessTokenCookie.toString())
-                    .header(HttpHeaders.SET_COOKIE,newRefreshTokenCookie.toString())
-                    .build();
-        }catch (Exception e){
-            log.error("토큰 갱신 중 오류 발생",e);
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(ApiResponse.error("토큰 갱신에 실패했습니다"));
         }
     }
 
@@ -156,9 +55,7 @@ public class MemberController {
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body(ApiResponse.error("회원을 찾을 수 없습니다")));
 
-
     }
-
 
 }
 

--- a/study/spring-board/src/main/java/com/kms/springboard/member/entity/MemberEntity.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/member/entity/MemberEntity.java
@@ -39,21 +39,9 @@ public class MemberEntity {
     @Column(name = "email" ,nullable = false, length = 255)
     private String email;
 
-    @PrePersist @PreUpdate
-    private void normalize(){
-        if(this.userId != null) this.userId = this.userId.trim().toLowerCase(Locale.ROOT);
-        if(this.email != null) this.email = this.email.trim().toLowerCase(Locale.ROOT);
-        if(this.username != null) this.username = this.username.trim();
-    }
 
-    public MemberDto convertToDto() {
-        return MemberDto.builder()
-                .userId(this.userId)
-                .username(this.username)
-                .email(this.email)
-                .build();
 
-    }
+
 
 
 }

--- a/study/spring-board/src/main/java/com/kms/springboard/member/repository/MemberRepository.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/member/repository/MemberRepository.java
@@ -3,7 +3,7 @@ package com.kms.springboard.member.repository;
 import com.kms.springboard.member.entity.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {

--- a/study/spring-board/src/main/java/com/kms/springboard/member/service/MemberService.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/member/service/MemberService.java
@@ -1,20 +1,14 @@
 package com.kms.springboard.member.service;
 
 
-import com.kms.springboard.member.dto.LoginDto;
 import com.kms.springboard.member.dto.MemberDto;
 import com.kms.springboard.member.entity.MemberEntity;
-import com.kms.springboard.security.jwt.dto.JwtTokenResponse;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;
 
 
 public interface MemberService {
 
-    MemberEntity save(MemberEntity member);
     MemberEntity saveDto(MemberDto memberDto);
-    boolean isLogin(LoginDto loginDto);
     Optional <MemberEntity> findByUserId(String userId);
-    JwtTokenResponse login(LoginDto loginDto);
 }

--- a/study/spring-board/src/main/java/com/kms/springboard/security/config/SecurityConfig.java
+++ b/study/spring-board/src/main/java/com/kms/springboard/security/config/SecurityConfig.java
@@ -1,8 +1,8 @@
-package com.kms.springboard.config;
+package com.kms.springboard.security.config;
 
 
-import com.kms.springboard.security.jwt.JwtAuthenticationFilter;
-import com.kms.springboard.security.jwt.JwtTokenProvider;
+import com.kms.springboard.auth.jwt.JwtAuthenticationFilter;
+import com.kms.springboard.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/study/spring-board/src/main/resources/application.properties
+++ b/study/spring-board/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+logging.level.org.springframework.web=debug

--- a/study/spring-board/src/main/resources/application.yml
+++ b/study/spring-board/src/main/resources/application.yml
@@ -71,5 +71,5 @@ spring:
 jwt:
   secret: ${JWT_SECRET}  # 환경변수에서 가져오기
   access-expiration-ms: ${JWT_EXPIRATION:86400000}  # 기본값 24시간
-  refresh-expiration-ms: ${JWT_REFRESH_EXPIRATION:60480000}
+  refresh-expiration-ms: ${JWT_REFRESH_EXPIRATION:604800000}
 

--- a/study/spring-board/src/main/resources/application.yml
+++ b/study/spring-board/src/main/resources/application.yml
@@ -42,7 +42,14 @@ spring:
     show-sql: false
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
+  data:
+    redis:     # redis
+      host: localhost
+      port: 6379
+      connect-timeout: 3000ms
+
 # 🔥 운영환경용 JWT 설정 (환경변수 사용 권장)
 jwt:
   secret: ${JWT_SECRET}  # 환경변수에서 가져오기
   expiration-ms: ${JWT_EXPIRATION:86400000}  # 기본값 24시간
+

--- a/study/spring-board/src/main/resources/application.yml
+++ b/study/spring-board/src/main/resources/application.yml
@@ -4,6 +4,8 @@ spring:
 
 ---
 spring:
+  main:
+    allow-bean-definition-overriding: true
   config:
     activate:
       on-profile: local
@@ -19,6 +21,13 @@ spring:
     show-sql: true
     database-platform: org.hibernate.dialect.MySQL8Dialect
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      connect-timeout: 3000ms
+      timeout: 3000ms
+
 # 🔥 JWT 설정 추가
 jwt:
   secret: "MyVerySecureJWTSecretKeyForDevelopmentThatIsAtLeast32BytesLongToMeetSecurityRequirements123456789"
@@ -27,6 +36,8 @@ jwt:
 
 ---
 spring:
+  main:
+    allow-bean-definition-overriding: true
   config:
     activate:
       on-profile: prod
@@ -44,12 +55,21 @@ spring:
 
   data:
     redis:     # redis
-      host: localhost
+      host: ${REDIS_HOST:localhost}
       port: 6379
       connect-timeout: 3000ms
+      timeout: 3000ms
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 0
+
+
 
 # 🔥 운영환경용 JWT 설정 (환경변수 사용 권장)
 jwt:
   secret: ${JWT_SECRET}  # 환경변수에서 가져오기
-  expiration-ms: ${JWT_EXPIRATION:86400000}  # 기본값 24시간
+  access-expiration-ms: ${JWT_EXPIRATION:86400000}  # 기본값 24시간
+  refresh-expiration-ms: ${JWT_REFRESH_EXPIRATION:60480000}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 전용 인증 API 추가: 로그인, 로그아웃, 토큰 재발급 엔드포인트(/api/auth).
  - Redis 기반 리프레시 토큰 저장 및 액세스 토큰 블랙리스트 구현.
  - 인증 서비스 및 토큰 관리 서비스 도입(토큰 발급/검증/로테이션/쿠키 처리).
  - 입력 정규화 컴포넌트 및 리프레시 토큰 DTO 추가.

- Refactor
  - 인증 관련 패키지 리워크 및 인증 책임을 별도 컨트롤러/서비스로 분리.
  - 회원 서비스/컨트롤러에서 기존 로그인·토큰 로직 제거 및 API 축소.

- Configuration
  - JWT 만료 설정을 액세스/리프레시로 분리하고 프로필별 Redis 설정 추가.
  - 보안 경로를 /api/auth/**로 업데이트.

- Chores
  - Docker Compose에 Redis 서비스 및 관련 설정 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->